### PR TITLE
Use the sNTP library to keep real time

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -239,9 +239,6 @@ void temperature_sensor_task(void *_args) {
             homekit_characteristic_notify(&current_temperature,
                                           current_temperature.value);
             homekit_characteristic_notify(&current_humidity, current_humidity.value);
-
-            // Update state, in case we should to turn the heater on or off
-            update_state();
         }
 
         // Update state, in case we should to turn the heater on or off. We


### PR DESCRIPTION
Fetch time from NTP servers using the sntp library in order to be able
to log temperature readings with a wall-clock timestamp.