### PR TITLE
Log temperature readings to an MQTT broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .python-version
 build
 sdkconfig
-wifi.h
+config.h

--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ When everything is installed, make sure you've checked out all the submodules:
 git submodule update --init --recursive
 ```
 
-Then you need to create an `wifi.h` in the project root with the following
+Then you need to create an `config.h` in the project root with the following
 contents:
 
 ```c
+#define SERIAL_NUMBER "<device serial>"
+
 #define WIFI_SSID "<your wifi ssid>"
 #define WIFI_PASSWORD "<your wifi mypassword>"
+
+#define MQTT_CLIENT_ID "<mqtt_id>"
+#define MQTT_TOPIC "<mqtt_topic>"
+#define MQTT_URI "mqtt://<host>"
 ```
 
 After that you can run `make` to compile the project.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ contents:
 #define WIFI_PASSWORD "<your wifi mypassword>"
 
 #define MQTT_CLIENT_ID "<mqtt_id>"
-#define MQTT_TOPIC "<mqtt_topic>"
 #define MQTT_URI "mqtt://<host>"
 ```
 

--- a/main/main.c
+++ b/main/main.c
@@ -246,7 +246,8 @@ void temperature_sensor_task(void *_args) {
             homekit_characteristic_notify(&current_humidity, current_humidity.value);
 
             // Log the read temperature
-            logger_log_temperature(temperature_value, humidity_value);
+            logger_log_temperature_and_relative_humidity(temperature_value,
+                                                         humidity_value);
         }
 
         // Update state, in case we should to turn the heater on or off. We

--- a/main/temperature_logger.c
+++ b/main/temperature_logger.c
@@ -1,0 +1,90 @@
+#include <stdio.h>
+#include <time.h>
+#include <sys/time.h>
+#include "temperature_logger.h"
+#include <mqtt_client.h>
+
+#include "config.h"
+
+#ifndef MQTT_CLIENT_ID
+#    error MQTT_CLIENT_ID is not defined, must be set in config.h
+#endif
+
+#ifndef MQTT_TOPIC
+#    error MQTT_TOPIC is not defined, must be set in config.h
+#endif
+
+#ifndef MQTT_URI
+#    error MQTT_URI is not defined, must be set in config.h
+#endif
+
+#define DATETIME_FORMAT "%FT%T%z"
+#define JSON_FORMAT                \
+    "{"                            \
+    "\"temperature\":%d.%d,"       \
+    "\"relative_humidity\":%d.%d," \
+    "\"timestamp\":\"%s\""         \
+    "}"
+
+// MQTT client
+static esp_mqtt_client_handle_t client;
+
+// Write a single temperature reading as a JSON object to the given buffer.
+static int temperature_reading_to_json(time_t time, int16_t temperature,
+                                       int16_t relative_humidity, char* buffer,
+                                       size_t buffer_length) {
+    // Format the given time as an ISO 8601 timestamp
+    char      strftime_buf[sizeof "2020-01-01T00:00:00+0000"];
+    struct tm timeinfo;
+    localtime_r(&time, &timeinfo);
+    strftime(strftime_buf, sizeof(strftime_buf), DATETIME_FORMAT, &timeinfo);
+
+    return snprintf(buffer, buffer_length, JSON_FORMAT, temperature / 10,
+                    temperature % 10, relative_humidity / 10, relative_humidity % 10,
+                    strftime_buf);
+}
+
+/**
+ * Initialize the logger
+ */
+esp_err_t logger_init() {
+    // Set up the configuration needed for the MQTT client
+    const esp_mqtt_client_config_t mqtt_cfg = {
+        .uri                   = MQTT_URI,
+        .client_id             = MQTT_CLIENT_ID,
+        .disable_clean_session = 1,
+    };
+
+    // Inititalize the client
+    client = esp_mqtt_client_init(&mqtt_cfg);
+    if (client == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Tell the MQTT client to connect. This will happen in the background.
+    return esp_mqtt_client_start(client);
+}
+
+/**
+ * Log a temperature reading to the MQTT broker.
+ */
+esp_err_t logger_log_temperature(int16_t temperature, int16_t relative_humidity) {
+    time_t now;
+    time(&now);
+    char buffer[100];
+
+    int bytes_written = temperature_reading_to_json(now, temperature, relative_humidity,
+                                                    buffer, sizeof(buffer));
+
+    if (bytes_written < 0) {
+        printf("Failed to serialize temperature reading\n");
+        return ESP_FAIL;
+    }
+
+    if (esp_mqtt_client_publish(client, MQTT_TOPIC, buffer, bytes_written, 2, 1) < 0) {
+        printf("Failed to publish message\n");
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}

--- a/main/temperature_logger.h
+++ b/main/temperature_logger.h
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <esp_err.h>
+
+/**
+ * Initialize the logger
+ */
+esp_err_t logger_init();
+
+/**
+ * Log a temperature reading to the MQTT broker.
+ */
+esp_err_t logger_log_temperature(int16_t temperature, int16_t relative_humidity);

--- a/main/temperature_logger.h
+++ b/main/temperature_logger.h
@@ -9,4 +9,5 @@ esp_err_t logger_init();
 /**
  * Log a temperature reading to the MQTT broker.
  */
-esp_err_t logger_log_temperature(int16_t temperature, int16_t relative_humidity);
+esp_err_t logger_log_temperature_and_relative_humidity(int16_t temperature,
+                                                       int16_t relative_humidity);


### PR DESCRIPTION
As a simple way to keep a log of the temperature readings, start logging
temperature readings to an MQTT broker.